### PR TITLE
DMS-1218: Replaced json.loads with ast.literal_eval

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 2.0.0b2 (unreleased)
 --------------------
 
-- Nothing changed yet.
-
+- Replaced `json.loads` with `ast.literal_eval` (DMS-1218).
+  [chris-adam]
 
 2.0.0b1 (2026-06-19)
 --------------------

--- a/src/dexterity/localroles/browser/settings.py
+++ b/src/dexterity/localroles/browser/settings.py
@@ -38,7 +38,7 @@ from zope.component import getUtility
 from zope.interface import implementer
 from zope.interface import Interface
 
-import json
+import ast
 
 
 try:
@@ -124,7 +124,7 @@ class RelatedFormatValidator(validator.SimpleFieldValidator):
         if not value or not value.strip():
             return
         try:
-            var = json.loads(value)
+            var = ast.literal_eval(value)
         except Exception:
             raise RelatedFormatError
         if not isinstance(var, dict):

--- a/src/dexterity/localroles/browser/tests/test_settings.py
+++ b/src/dexterity/localroles/browser/tests/test_settings.py
@@ -60,6 +60,9 @@ class TestSettings(unittest.TestCase):
         self.assertIsNone(
             validator.validate('{"dexterity.localroles.related_parent":["Reader"]}')
         )
+        self.assertIsNone(
+            validator.validate("{'dexterity.localroles.related_parent': ['Reader']}")
+        )
 
     def test_localroleconfigurationadapter(self):
         class dummy(object):

--- a/src/dexterity/localroles/subscriber.py
+++ b/src/dexterity/localroles/subscriber.py
@@ -13,7 +13,7 @@ from plone import api
 from zope.lifecycleevent.interfaces import IObjectAddedEvent
 from zope.lifecycleevent.interfaces import IObjectRemovedEvent
 
-import json
+import ast
 
 
 def update_security(obj, event):
@@ -29,7 +29,7 @@ def related_role_removal(obj, state, fti_config):
         defer_security_update = obj.REQUEST.get("DEFER_SECURITY_UPDATE", False)
         for princ in dic:
             if dic[princ].get("rel"):
-                related = json.loads(dic[princ]["rel"])
+                related = ast.literal_eval(dic[princ]["rel"])
                 for utility in related:
                     if not related[utility]:
                         continue
@@ -47,7 +47,7 @@ def related_role_addition(obj, state, fti_config):
         defer_security_update = obj.REQUEST.get("DEFER_SECURITY_UPDATE", False)
         for princ in dic:
             if dic[princ].get("rel"):
-                related = json.loads(dic[princ]["rel"])
+                related = ast.literal_eval(dic[princ]["rel"])
                 for utility in related:
                     if not related[utility]:
                         continue


### PR DESCRIPTION
## Summary
Backward-compatible parsing of the local-roles `related` (`rel`) config: replaces strict `json.loads` with `ast.literal_eval` in `subscriber.py` (related role add/remove) and the `RelatedFormatValidator`, so both legacy single-quoted Python-repr and JSON are accepted. This fixes workflow-transition crashes on sites whose `rel` config predates the eval→JSON switch (SUP-54082 / DMS-1218). `ast.literal_eval` only evaluates literals, so the security intent of restricting the field is preserved; the separate `is_valid_json` field constraint is left intact.

## Ticket
DMS-1218 — https://support-imio.atlassian.net/browse/DMS-1218

## Pre-PR checks
- [x] CHANGES up to date
- [x] Tests exist for new code (`test_settings.py`)
- [x] Diff matches ticket
- [x] No debug leftovers
- [x] No stray files / secrets
- [x] Profile / version bumps (n/a — no profile change)
- [x] Commits reference ticket / mergeable

## Commits
a326e60 DMS-1218: Replaced json.loads with ast.literal_eval
